### PR TITLE
use "GMT" as default timezone name

### DIFF
--- a/lib/azurex/authorization/shared_key.ex
+++ b/lib/azurex/authorization/shared_key.ex
@@ -55,9 +55,11 @@ defmodule Azurex.Authorization.SharedKey do
     put_signature(request, signature, storage_account_name, storage_account_key)
   end
 
+  @default_timezone "GMT"
   defp put_standard_headers(request, content_type) do
     now =
-      Timex.now("GMT") |> Timex.format!("{WDshort}, {0D} {Mshort} {YYYY} {h24}:{m}:{s} {Zname}")
+      Timex.now(@zone_name)
+      |> Timex.format!("{WDshort}, {0D} {Mshort} {YYYY} {h24}:{m}:{s} #{@default_timezone}")
 
     headers =
       if content_type,


### PR DESCRIPTION
ref issue: https://github.com/jakobht/azurex/issues/18

since Timex 3.7.2 the default `GMT` is changed to `UTC` 
link : https://hexdocs.pm/timex/3.7.2/changelog.html#potentially-breaking

and the formatter vars `Zname` no longer refer to `GMT` but `UTC`
link: https://hexdocs.pm/timex/Timex.Format.DateTime.Formatters.Strftime.html#module-time-zones



