### PR TITLE
fix list containers

### DIFF
--- a/lib/azurex/blob.ex
+++ b/lib/azurex/blob.ex
@@ -11,7 +11,8 @@ defmodule Azurex.Blob do
 
   def list_containers do
     %HTTPoison.Request{
-      url: Config.api_url() <> "/?comp=list"
+      url: Config.api_url() <> "/",
+      params: [comp: "list"]
     }
     |> SharedKey.sign(
       storage_account_name: Config.storage_account_name(),

--- a/test/integration/blob_integration_test.exs
+++ b/test/integration/blob_integration_test.exs
@@ -71,6 +71,12 @@ defmodule Azurex.BobIntegrationTests do
     end
   end
 
+  describe "test containers" do
+    test "list containers" do
+      assert {:ok, _results} = Blob.list_containers
+    end
+  end
+
   defp make_blob_name do
     escaped_time =
       DateTime.utc_now()


### PR DESCRIPTION
After upgrading to erlang 24 and elixir 1.12.2,  receiving authentication failed on list_containers.  The put_blob call worked.  

Here was the error:

```
iex(1)> Azurex.Blob.list_containers
{:error,
 %HTTPoison.Response{
   body: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>AuthenticationFailed</Code><Message>Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature....
```
This PR updates the HTTPoison.Request to pass comp=list through params and adds a test for list_containers 