### PR TITLE
Adds HEAD methods to check if blobs/containers exist

### DIFF
--- a/lib/azurex/blob/container.ex
+++ b/lib/azurex/blob/container.ex
@@ -1,0 +1,26 @@
+defmodule Azurex.Blob.Container do
+  @moduledoc """
+  Implementation of Azure Blob Storage
+  """
+  alias Azurex.Blob.Config
+  alias Azurex.Authorization.SharedKey
+
+  def head_container(container) do
+    %HTTPoison.Request{
+      url: Config.api_url() <> "/" <> container,
+      params: [restype: "container"],
+      method: :head
+    }
+    |> SharedKey.sign(
+      storage_account_name: Config.storage_account_name(),
+      storage_account_key: Config.storage_account_key()
+    )
+    |> HTTPoison.request()
+    |> case do
+      {:ok, %{status_code: 200, headers: headers}} -> {:ok, headers}
+      {:ok, %HTTPoison.Response{status_code: 404}} -> {:error, :not_found}
+      {:ok, err} -> {:error, err}
+      {:error, err} -> {:error, err}
+    end
+  end
+end

--- a/test/integration/container_integration_test.exs
+++ b/test/integration/container_integration_test.exs
@@ -1,0 +1,22 @@
+defmodule Azurex.ContainerIntegrationTests do
+  use ExUnit.Case, async: false
+  alias Azurex.Blob.Container
+
+  @moduletag integration: true
+  @integration_testing_container "integrationtestingcontainer"
+
+  describe "head container" do
+    test "returns ok when the container exists" do
+      assert {:ok, _} = Container.head_container(@integration_testing_container)
+    end
+
+    test "returns not_found when the container does not exist" do
+      assert {:error, :not_found} = Container.head_container("thiscontainershouldnotexist")
+    end
+
+    test "returns an error when the container name is invalid" do
+      assert {:error, %HTTPoison.Response{status_code: 400}} =
+               Container.head_container("Thi$isinvalid")
+    end
+  end
+end


### PR DESCRIPTION
This commit adds "HEAD" methods to blobs and containers so that a server can check if the blob/container exists without needing to download the whole file.