### PR TITLE
Removed Timex dependency - Waiting for elixir 1.10 support to stop

### DIFF
--- a/lib/azurex/authorization/shared_key.ex
+++ b/lib/azurex/authorization/shared_key.ex
@@ -75,8 +75,7 @@ defmodule Azurex.Authorization.SharedKey do
 
   def format_date(%DateTime{zone_abbr: "UTC"} = date_time) do
     date_time
-    # We use Timex strftime, as Calendar.strftime in the std is only availible from Elixir 1.11
-    |> Timex.Format.DateTime.Formatters.Strftime.format!("%a, %d %b %Y %H:%M:%S GMT")
+    |> Calendar.strftime("%a, %d %b %Y %H:%M:%S GMT")
   end
 
   defp get_method(request), do: request.method |> Atom.to_string() |> String.upcase()

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,6 @@ defmodule Azurex.MixProject do
       {:dialyxir, "~> 1.1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:httpoison, "~> 1.8"},
-      {:timex, "~> 3.7"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Azurex.MixProject do
     [
       {:dialyxir, "~> 1.1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
-      {:httpoison, "~> 1.8"},
+      {:httpoison, "~> 1.8"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -18,7 +18,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.3.1", "2c54013ecf170e249e9291ed0a62e5832f70a476c61da16f6aac6dca0189f2af", [:mix], [], "hexpm", "2682e3c0b2eb58d90c6375fc0cc30bc7be06f365bf72608804fb9cffa5e1b167"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
-  "timex": {:hex, :timex, "3.7.11", "bb95cb4eb1d06e27346325de506bcc6c30f9c6dea40d1ebe390b262fad1862d1", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.20", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 1.1", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm", "8b9024f7efbabaf9bd7aa04f65cf8dcd7c9818ca5737677c7b76acbc6a94d1aa"},
   "tzdata": {:hex, :tzdata, "1.1.1", "20c8043476dfda8504952d00adac41c6eda23912278add38edc140ae0c5bcc46", [:mix], [{:hackney, "~> 1.17", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm", "a69cec8352eafcd2e198dea28a34113b60fdc6cb57eb5ad65c10292a6ba89787"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }


### PR DESCRIPTION
We do not need timex anymore, as the least supported version of elixir is `1.11` which includes `Calendar.strftime`