### PR TITLE
Adds a method for creating containers

### DIFF
--- a/lib/azurex/blob/container.ex
+++ b/lib/azurex/blob/container.ex
@@ -23,4 +23,24 @@ defmodule Azurex.Blob.Container do
       {:error, err} -> {:error, err}
     end
   end
+
+  def create(container) do
+    %HTTPoison.Request{
+      url: Config.api_url() <> "/" <> container,
+      params: [restype: "container"],
+      method: :put
+    }
+    |> SharedKey.sign(
+      storage_account_name: Config.storage_account_name(),
+      storage_account_key: Config.storage_account_key(),
+      content_type: "application/octet-stream"
+    )
+    |> HTTPoison.request()
+    |> case do
+      {:ok, %{status_code: 201}} -> {:ok, container}
+      {:ok, %HTTPoison.Response{status_code: 409}} -> {:error, :already_exists}
+      {:ok, err} -> {:error, err}
+      {:error, err} -> {:error, err}
+    end
+  end
 end

--- a/test/integration/container_integration_test.exs
+++ b/test/integration/container_integration_test.exs
@@ -26,4 +26,22 @@ defmodule Azurex.ContainerIntegrationTests do
                Container.head_container("Thi$isinvalid")
     end
   end
+
+  describe "create container" do
+    test "creates a new container" do
+      container_name = for _ <- 1..32, into: "", do: <<Enum.random('abcdefghijklmnopqrstuvwxyz')>>
+
+      assert {:error, :not_found} = Container.head_container(container_name)
+      assert {:ok, ^container_name} = Container.create(container_name)
+      assert {:ok, _} = Container.head_container(container_name)
+    end
+
+    test "returns an error if the container already exists" do
+      assert {:error, :already_exists} = Container.create(@integration_testing_container)
+    end
+
+    test "returns an error if the container name is invalid" do
+      assert {:error, %HTTPoison.Response{status_code: 400}} = Container.create("@$1")
+    end
+  end
 end


### PR DESCRIPTION
This would be useful for setting up the CI pipeline, if you want to run integration tests on Github:
```
mix run -e "Azurex.Blob.Container.create(~s{test})"
mix run -e "Azurex.Blob.Container.create(~s{integrationtestingcontainer})"
```