### PR TITLE
Add header when put_blob

### DIFF
--- a/lib/azurex/blob.ex
+++ b/lib/azurex/blob.ex
@@ -61,6 +61,9 @@ defmodule Azurex.Blob do
       iex> put_blob("filename.txt", "file contents", "text/plain")
       {:error, %HTTPoison.Response{}}
 
+      iex> put_blob("filename.txt", "file contents", "text/plain", headers: [{"x-ms-meta-id", "1234"}])
+      {:error, %HTTPoison.Response{}}
+
   """
   @spec put_blob(
           String.t(),

--- a/lib/azurex/blob.ex
+++ b/lib/azurex/blob.ex
@@ -61,9 +61,6 @@ defmodule Azurex.Blob do
       iex> put_blob("filename.txt", "file contents", "text/plain")
       {:error, %HTTPoison.Response{}}
 
-      iex> put_blob("filename.txt", "file contents", "text/plain")
-      {:error, %HTTPoison.Response{}}
-
   """
   @spec put_blob(
           String.t(),

--- a/lib/azurex/blob.ex
+++ b/lib/azurex/blob.ex
@@ -61,6 +61,9 @@ defmodule Azurex.Blob do
       iex> put_blob("filename.txt", "file contents", "text/plain")
       {:error, %HTTPoison.Response{}}
 
+      iex> put_blob("filename.txt", "file contents", "text/plain")
+      {:error, %HTTPoison.Response{}}
+
   """
   @spec put_blob(
           String.t(),
@@ -94,14 +97,19 @@ defmodule Azurex.Blob do
   def put_blob(name, blob, content_type, container, params) do
     content_type = content_type || "application/octet-stream"
 
+    headers =
+      [
+        {"x-ms-blob-type", "BlockBlob"}
+      ] ++ Keyword.get(params, :headers, [])
+
+    params = params |> Keyword.delete(:headers)
+
     %HTTPoison.Request{
       method: :put,
       url: get_url(container, name),
       params: params,
       body: blob,
-      headers: [
-        {"x-ms-blob-type", "BlockBlob"}
-      ],
+      headers: headers,
       # Blob storage only answers when the whole file has been uploaded, so recv_timeout
       # is not applicable for the put request, so we set it to infinity
       options: [recv_timeout: :infinity]

--- a/test/integration/blob_integration_test.exs
+++ b/test/integration/blob_integration_test.exs
@@ -159,6 +159,26 @@ defmodule Azurex.BlobIntegrationTests do
       assert {:ok, _result_not_checked} =
                Blob.list_blobs(@integration_testing_container, timeout: 10)
     end
+
+    test "passing container and params and header" do
+      blob_name = make_blob_name()
+
+      assert Blob.put_blob(
+               blob_name,
+               @sample_file_contents,
+               "text/plain",
+               @integration_testing_container,
+               timeout: 10,
+               ignored_param: "ignored_param_value",
+               headers: [{"x-ms-meta-id", "1234"}]
+             ) == :ok
+
+      assert Blob.get_blob(
+               blob_name,
+               @integration_testing_container,
+               timeout: 10
+             ) == {:ok, @sample_file_contents}
+    end
   end
 
   describe "test containers" do


### PR DESCRIPTION
When calling put_blob, you can set various values through headers, such as metadata and tags. To preserve the existing function parameters, ‘headers’ have been added to ‘params’.